### PR TITLE
Feature: Add tell_time skill

### DIFF
--- a/ace/config.py
+++ b/ace/config.py
@@ -23,4 +23,13 @@ INTENT_PATTERNS = {
         r"(?P<timeframe>current) weather",
         r"weather (?P<timeframe>today)",
     ],
+    "TELL_TIME_SKILL": [
+        r"what is the time",
+        r"what time is it",
+        r"tell me the time",
+        r"current time",
+        r"time (?:.*) in (?P<timevalue>.*) (?P<timeunit>hour|minute|second)",
+        r"time in (?P<timevalue>.*) (?P<timeunit>hour|minute|second)",
+        r"time now",
+    ],
 }

--- a/ace/skills.py
+++ b/ace/skills.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from random import choice
 
 from dotenv import load_dotenv
@@ -111,3 +112,47 @@ def get_weather_skill(entities=None) -> str:
 
     except KeyError:
         return "Sorry, there was an error processing the weather data."
+
+
+def tell_time_skill(entities=None) -> str:
+    """Tell the current time or calculate future time."""
+    time_value = entities.get("timevalue", 0)
+    time_unit = entities.get("timeunit", None)
+
+    if time_value == 0:
+        response_templates_current = [
+            "The current time is {time}",
+            "It's {time} now",
+            "The time is {time}",
+            "It's currently {time}",
+        ]
+
+        current_time = datetime.now().strftime("%H:%M %p")
+        return choice(response_templates_current).format(time=current_time)
+
+    if time_unit:
+        response_templates_future = [
+            "The time will be {future_time} in {time_value} {time_unit}",
+            "It will be {future_time} in {time_value} {time_unit}",
+            "The time will be {future_time}",
+            "It will be {future_time}",
+        ]
+
+        time_format_config = {
+            "hour": "%H:%M %p",
+            "minute": "%H:%M %p",
+            "second": "%H:%M:%S %p",
+        }
+
+        plural = "s" if float(time_value) > 1 else ""
+
+        future_time = datetime.now() + timedelta(**{time_unit + "s": int(time_value)})
+        future_time = future_time.strftime(
+            time_format_config.get(time_unit, "%H:%M %p")
+        )
+
+        return choice(response_templates_future).format(
+            future_time=future_time,
+            time_value=time_value,
+            time_unit=time_unit + plural,
+        )

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -102,6 +102,22 @@ class TestRecogniseIntent(unittest.TestCase):
                 intent = recognise_intent(parameter)
                 self.assertEqual(intent, "GET_WEATHER_SKILL")
 
+    def test_tell_time_skill(self):
+        parameters = [
+            "what time is it",
+            "tell me the time",
+            "current time",
+            "what time will it be in 5 minutes",
+            "what time will it be in 2 hours",
+            "what is the time now",
+            "give me the time in 10 seconds",
+        ]
+
+        for parameter in parameters:
+            with self.subTest(parameter=parameter):
+                intent = recognise_intent(parameter)
+                self.assertEqual(intent, "TELL_TIME_SKILL")
+
 
 class TestExtractEntities(unittest.TestCase):
     def test_extract_entities_DUMMY_SKILL(self):
@@ -195,6 +211,32 @@ class TestExtractEntities(unittest.TestCase):
             with self.subTest(text=text, expected=expected):
                 entities = extract_entities(text, intent)
                 # entities can be in any order
+                self.assertEqual(entities, expected)
+
+    def test_extract_entities_TELL_TIME_SKILL(self):
+        intent = "TELL_TIME_SKILL"
+        parameters = [
+            (
+                "what time will it be in 5 minutes",
+                {"timevalue": "5", "timeunit": "minute"},
+            ),
+            (
+                "what time will it be in 2 hours",
+                {"timevalue": "2", "timeunit": "hour"},
+            ),
+            (
+                "what time will it be in 10 seconds",
+                {"timevalue": "10", "timeunit": "second"},
+            ),
+            (
+                "tell me the time",
+                {},
+            ),
+        ]
+
+        for text, expected in parameters:
+            with self.subTest(text=text, expected=expected):
+                entities = extract_entities(text, intent)
                 self.assertEqual(entities, expected)
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,6 +1,7 @@
 import os
 import random
 import unittest
+from datetime import datetime
 from unittest.mock import patch
 
 from dotenv import load_dotenv
@@ -220,6 +221,68 @@ class TestSkillGetWeather(unittest.TestCase):
             with self.subTest(error=error, expected_response=expected_response):
                 mock_call_weather_api.side_effect = error
                 self.assertEqual(self.skill(entities), expected_response)
+
+
+class TestSkillTellTime(unittest.TestCase):
+    def setUp(self):
+        self.skill = skills_dict["TELL_TIME_SKILL"]
+        random.seed(42)
+
+    @patch("ace.skills.datetime")
+    def test_tell_time_now(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2021, 8, 1, 12, 0, 0)
+
+        possible_responses = [
+            "The current time is 12:00 PM",
+            "It's 12:00 PM now",
+            "The time is 12:00 PM",
+            "It is currently 12:00 PM",
+        ]
+
+        entities = {}
+
+        self.assertIn(self.skill(entities), possible_responses)
+
+    @patch("ace.skills.datetime")
+    def test_tell_time_future(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2021, 8, 1, 12, 0, 0)
+
+        parameters = [
+            (
+                {"timevalue": "1", "timeunit": "hour"},
+                [
+                    "The time will be 13:00 PM in 1 hour",
+                    "It will be 13:00 PM in 1 hour",
+                    "The time will be 13:00 PM",
+                    "It will be 13:00 PM",
+                ],
+            ),
+            (
+                {"timevalue": "30", "timeunit": "minute"},
+                [
+                    "The time will be 12:30 PM in 30 minutes",
+                    "It will be 12:30 PM in 30 minutes",
+                    "The time will be 12:30 PM",
+                    "It will be 12:30 PM",
+                ],
+            ),
+            (
+                {"timevalue": "10", "timeunit": "second"},
+                [
+                    "The time will be 12:00:10 PM in 10 seconds",
+                    "It will be 12:00:10 PM in 10 seconds",
+                    "The time will be 12:00:10 PM",
+                    "It will be 12:00:10 PM",
+                ],
+            ),
+        ]
+
+        for entities, expected_responses in parameters:
+            with self.subTest(entities=entities, expected_responses=expected_responses):
+                actual_response = self.skill(entities)
+                self.assertTrue(
+                    any(expected in actual_response for expected in expected_responses)
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds the `tell_time_skill` to ACE, allowing it to tell the current time and calculate future times.

Changes:

- Implemented the `tell_time_skill` function in `skills.py`.
- Added intent patterns for the `TELL_TIME` intent in `config.py`.
- Updated the `skills_dict` to include the `tell_time_skill`.
- Added comprehensive unit tests for the `tell_time_skill` in `test_skills.py`.

This enhancement allows ACE to provide the current time and calculate future times, making it a more versatile and helpful assistant.