### PR TITLE
Update ace package version to use CalVer

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,5 +3,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ace"
-version = "0.1.0"
+version = "2024.12.0"
 source = { virtual = "." }


### PR DESCRIPTION
Update the initial package version to use [CalVer](https://calver.org/), with the format `YYYY.0M.PATCH`:
* YYYY: The four digit year, e.g. 2003, 2024
* 0M: The zero-padded month number, e.g. 01, 10
* PATCH: The patch, starting at zero, to allow for multiple (minor) releases in a month