### PR TITLE
chore: Ignore IDE configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # Database files
 *.db
+
+# IDE files
+.vscode/


### PR DESCRIPTION
This pull request adds the `.vscode/` entry to the `.gitignore` file to prevent IDE configuration files from being tracked by Git.

Ignoring IDE configuration files helps to:

* Keep the repository clean and focused on essential project files.
* Avoid conflicts when different developers use different IDEs or settings.
* Prevent sensitive information (like API keys or local paths) from being accidentally committed.